### PR TITLE
Added unordered-containers to deps and strict hashmap instance

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -7,7 +7,7 @@ Name:                safecopy
 -- The package version. See the Haskell package versioning policy
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
-Version:             0.8.3
+Version:             0.8.4
 
 -- A short (one-line) description of the package.
 Synopsis:            Binary serialization with version control.
@@ -55,8 +55,9 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >=4 && <5, array, cereal >= 0.3.1.0, bytestring, containers >= 0.3,
-                       old-time, template-haskell, text, time, vector == 0.10.*
-
+                       old-time, template-haskell, text, time, unordered-containers >= 0.2.3.0,
+                       vector == 0.10.*, hashable >= 1.1.2.5
+                       
   -- Modules not exported by this package.
   Other-modules:       Data.SafeCopy.Instances, Data.SafeCopy.SafeCopy,
                        Data.SafeCopy.Derive

--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -8,6 +8,8 @@ import           Control.Applicative
 import           Control.Monad
 import qualified Data.Array as Array
 import qualified Data.Array.Unboxed as UArray
+import qualified Data.HashMap.Strict as HS
+import Data.Hashable
 import qualified Data.Array.IArray as IArray
 import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.ByteString.Char8 as B
@@ -402,3 +404,8 @@ instance (SafeCopy a, VS.Storable a) => SafeCopy (VS.Vector a) where
 instance (SafeCopy a, VU.Unbox a) => SafeCopy (VU.Vector a) where
     getCopy = getGenericVector
     putCopy = putGenericVector
+
+instance (SafeCopy a, SafeCopy b, Eq a, Hashable a) =>
+    SafeCopy (HS.HashMap a b) where
+      getCopy = contain $ fmap HS.fromList safeGet
+      putCopy = contain . safePut . HS.toList


### PR DESCRIPTION
I'd like to use a strict `HashMap` instead of `Map` w/ `acid-state` since it is a more performant data structure (according to these benchmarks: http://gregorycollins.net/posts/2011/06/11/announcing-hashtables). Figured adding the `safecopy` instances directly to the safecopy package would be a good idea. The dependency on `unordered-containers` shouldn't be a problem since it's a widely used package, but let me know if you think otherwise. Version bump included.
