### PR TITLE
Hid Data.Typeable.Proxy export to satsify build

### DIFF
--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts, UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.SafeCopy.Instances where
@@ -31,7 +32,11 @@ import           Data.Time.Clock (DiffTime, NominalDiffTime, UniversalTime(..), 
 import           Data.Time.Clock.TAI (AbsoluteTime, taiEpoch, addAbsoluteTime, diffAbsoluteTime)
 import           Data.Time.LocalTime (LocalTime(..), TimeOfDay(..), TimeZone(..), ZonedTime(..))
 import qualified Data.Tree as Tree
+#if MIN_VERSION_base(4,7,0)
 import           Data.Typeable hiding (Proxy)
+#else
+import           Data.Typeable
+#endif
 import           Data.Word
 import           System.Time (ClockTime(..), TimeDiff(..), CalendarTime(..), Month(..))
 import qualified System.Time as OT

--- a/test/instances.hs
+++ b/test/instances.hs
@@ -25,7 +25,7 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import Test.QuickCheck.Instances ()
 import Test.Tasty
-import Test.Tasty.QuickCheck hiding (Fixed)
+import Test.Tasty.QuickCheck hiding (Fixed, (===))
 import qualified Data.Vector as V
 import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Storable as VS


### PR DESCRIPTION
Fixed this

``` haskell
src/Data/SafeCopy/Instances.hs:379:31:
    Ambiguous occurrence ‘Proxy’
    It could refer to either ‘Data.SafeCopy.SafeCopy.Proxy’,
                             imported from ‘Data.SafeCopy.SafeCopy’ at src/Data/SafeCopy/Instances.hs:5:1-29
                             (and originally defined at src/Data/SafeCopy/SafeCopy.hs:391:1-20)
                          or ‘Data.Typeable.Proxy’,
                             imported from ‘Data.Typeable’ at src/Data/SafeCopy/Instances.hs:34:1-30
                             (and originally defined in ‘Data.Proxy’)
```
