### PR TITLE
silence warnings for base-4.8.0/ghc-7.10.1

### DIFF
--- a/src/Data/SafeCopy/Derive.hs
+++ b/src/Data/SafeCopy/Derive.hs
@@ -23,7 +23,9 @@ import Language.Haskell.TH hiding (Kind)
 #else
 import Language.Haskell.TH hiding (Kind(..))
 #endif
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
+#endif
 import Control.Monad
 import Data.Maybe (fromMaybe)
 #ifdef __HADDOCK__

--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -5,7 +5,9 @@ module Data.SafeCopy.Instances where
 
 import Data.SafeCopy.SafeCopy
 
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
+#endif
 import           Control.Monad
 import qualified Data.Array as Array
 import qualified Data.Array.Unboxed as UArray


### PR DESCRIPTION
This silences the warnings about redundancy of Applicative imports.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/acid-state/safecopy/22)
<!-- Reviewable:end -->
