### PR TITLE
Doesn't build on GHC < 7.4

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -54,7 +54,7 @@ Library
   Hs-Source-Dirs:      src/
 
   -- Packages needed in order to build this package.
-  Build-depends:       base >=4 && <5, array, cereal >= 0.3.1.0, bytestring, containers >= 0.3,
+  Build-depends:       base >=4.5 && <5, array, cereal >= 0.3.1.0, bytestring, containers >= 0.3,
                        old-time, template-haskell, text, time, vector == 0.10.*
 
   -- Modules not exported by this package.


### PR DESCRIPTION
I've revised existing versions: http://hackage.haskell.org/package/safecopy-0.8.5/revisions/

A new release is only required if you wish to restore GHC < 7.4 compatibility.

Build error:
```
src/Data/SafeCopy/SafeCopy.hs:142:5:
    Couldn't match type `a0' with `a1'
      because type variable `a1' would escape its scope
    This (rigid, skolem) type variable is bound by
      the type signature for
        worker :: SafeCopy a1 =>
                  Bool -> Version a1 -> Kind a1 -> Either String (Get a1)
    The following variables have types that mention a0
      errorMsg :: Kind a0 -> [Char] -> [Char]
        (bound at src/Data/SafeCopy/SafeCopy.hs:163:5)
    In an equation for `constructGetterFromVersion':
        constructGetterFromVersion diskVersion orig_kind
          = worker False diskVersion orig_kind
          where
              worker ::
                forall a. SafeCopy a =>
                Bool -> Version a -> Kind a -> Either String (Get a)
              worker fwd thisVersion thisKind
                | version == thisVersion = return $ unsafeUnPack getCopy
                | otherwise
                = case thisKind of {
                    Primitive
                      -> Left $ errorMsg thisKind "Cannot migrate from primitive types."
                    Base -> Left $ errorMsg thisKind versionNotFound
                    Extends b_proxy -> ...
                    Extended {} | fwd -> Left $ errorMsg thisKind versionNotFound
                    Extended a_kind -> ... }
              versionNotFound
                = "Cannot find getter associated with this version number: "
                  ++ show diskVersion
              errorMsg fail_kind msg = concat ["safecopy: ", ....]
```