### PR TITLE
Loosen vector dependency

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -55,7 +55,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >=4 && <5, array, cereal >= 0.3.1.0, bytestring, containers >= 0.3,
-                       old-time, template-haskell, text, time, vector == 0.10.*
+                       old-time, template-haskell, text, time, vector >= 0.10
 
   -- Modules not exported by this package.
   Other-modules:       Data.SafeCopy.Instances, Data.SafeCopy.SafeCopy,


### PR DESCRIPTION
It builds fine for newer versions of vector, so we might as well allow them.