### PR TITLE
Add SafeCopy instances for HashMap and HashSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
 *.nix
+
+# Created by https://www.gitignore.io/api/haskell
+
+### Haskell ###
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+.stack-work/

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -55,7 +55,8 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends:       base >=4.5 && <5, array, cereal >= 0.3.1.0, bytestring, containers >= 0.3,
-                       old-time, template-haskell, text, time, vector >= 0.10
+                       hashable, old-time, template-haskell, text, time, unordered-containers,
+                       vector >= 0.10
 
   -- Modules not exported by this package.
   Other-modules:       Data.SafeCopy.Instances, Data.SafeCopy.SafeCopy,

--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -16,6 +16,9 @@ import qualified Data.ByteString.Lazy.Char8 as L
 import qualified Data.ByteString.Char8 as B
 import qualified Data.Foldable as Foldable
 import           Data.Fixed (HasResolution, Fixed)
+import           Data.Hashable
+import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashSet as HashSet
 import           Data.Int
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
@@ -87,6 +90,16 @@ instance (SafeCopy a, SafeCopy b, Ord a) => SafeCopy (Map.Map a b) where
     getCopy = contain $ fmap Map.fromDistinctAscList safeGet
     putCopy = contain . safePut . Map.toAscList
     errorTypeName = typeName2
+
+instance (Eq a, Hashable a, SafeCopy a, SafeCopy b) => SafeCopy (HashMap.HashMap a b) where
+    getCopy = contain $ fmap HashMap.fromList safeGet
+    putCopy = contain . safePut . HashMap.toList
+    errorTypeName = typeName2
+
+instance (Eq a, Hashable a, SafeCopy a) => SafeCopy (HashSet.HashSet a) where
+    getCopy = contain $ fmap HashSet.fromList safeGet
+    putCopy = contain . safePut . HashSet.toList
+    errorTypeName = typeName1
 
 instance (SafeCopy a) => SafeCopy (IntMap.IntMap a) where
     getCopy = contain $ fmap IntMap.fromDistinctAscList safeGet


### PR DESCRIPTION
I added the SafeCopy instances for HashMap and HashSet, since these two are widely used and yet not supported by SafeCopy.