### PR TITLE
tweak build against QuickCheck-2.8.2 (vector instances)

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -87,4 +87,4 @@ Test-suite instances
   GHC-Options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   Build-depends:       base, cereal, template-haskell, safecopy,
                        containers, time, array, vector, lens >= 4.7 && < 5.0,
-                       lens-action, tasty, tasty-quickcheck, quickcheck-instances
+                       lens-action, tasty, tasty-quickcheck, quickcheck-instances, QuickCheck

--- a/test/instances.hs
+++ b/test/instances.hs
@@ -42,6 +42,7 @@ instance (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e, Arbit
    arbitrary = (,,,,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*>
                             arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
+#if ! MIN_VERSION_QuickCheck(2,8,2)
 instance (Arbitrary a) => Arbitrary (V.Vector a) where
    arbitrary = V.fromList <$> arbitrary
 
@@ -53,6 +54,7 @@ instance (Arbitrary a, VS.Storable a) => Arbitrary (VS.Vector a) where
 
 instance (Arbitrary a, VU.Unbox a) => Arbitrary (VU.Vector a) where
    arbitrary = VU.fromList <$> arbitrary
+#endif
 
 deriving instance (Arbitrary a) => Arbitrary (Prim a)
 deriving instance (Eq a) => Eq (Prim a)


### PR DESCRIPTION
GHC failed as:
  [1 of 1] Compiling Main             ( test/instances.hs, dist/build/instances/instances-tmp/Main.dyn_o )

  test/instances.hs:45:10:
    Duplicate instance declarations:
      instance Arbitrary a => Arbitrary (V.Vector a)
        -- Defined at test/instances.hs:45:10
      instance Arbitrary a => Arbitrary (V.Vector a)
        -- Defined in ‘Test.QuickCheck.Instances’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>