### PR TITLE
Expose internal TH derivation helpers

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -50,6 +50,7 @@ Source-repository head
 Library
   -- Modules exported by the library.
   Exposed-modules:     Data.SafeCopy
+                       Data.SafeCopy.Internal
 
   Hs-Source-Dirs:      src/
 

--- a/src/Data/SafeCopy/Internal.hs
+++ b/src/Data/SafeCopy/Internal.hs
@@ -1,0 +1,7 @@
+module Data.SafeCopy.Internal (
+    module Data.SafeCopy.SafeCopy
+  , module Data.SafeCopy.Derive
+  ) where
+
+import Data.SafeCopy.SafeCopy
+import Data.SafeCopy.Derive


### PR DESCRIPTION
Hi,

I'm working on a package for automatically keeping old versions of datatypes around and I'd like to derive `SafeCopy` instances for the datatypes my TH code spits out. However `reify` can't access datatypes defined in the current splice so I need more low level access to the derivation machinery.

See https://github.com/DanielG/safecopy-history
