### PR TITLE
Allow containers-0.6 and template-haskell-2.14

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -34,7 +34,7 @@ Library
                        array < 0.6,
                        cereal >= 0.5 && < 0.6,
                        bytestring < 0.11,
-                       containers >= 0.3 && < 0.6,
+                       containers >= 0.3 && < 0.7,
                        old-time < 1.2,
                        template-haskell < 2.15,
                        text < 1.3,

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -36,7 +36,7 @@ Library
                        bytestring < 0.11,
                        containers >= 0.3 && < 0.6,
                        old-time < 1.2,
-                       template-haskell < 2.14,
+                       template-haskell < 2.15,
                        text < 1.3,
                        time < 1.9,
                        vector >= 0.10 && < 0.13


### PR DESCRIPTION
This is necessary to build `safecopy` with GHC 8.6.1.

Fixes #68.