### PR TITLE
Fully generic implementation of putCopy and getCopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,15 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.2.1
-      compiler: ": #GHC 8.2.1"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
-    - env: CABALVER=2.2 GHCVER=8.4.1
-      compiler: ": #GHC 8.4.1"
-      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.2
+      compiler: ": #GHC 8.2.2"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.4.4
+      compiler: ": #GHC 8.4.4"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4 GHCVER=8.6.5
+      compiler: ": #GHC 8.6.5"
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       compiler: ": #GHC HEAD"
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -15,7 +15,7 @@ Category:            Data, Parsing
 Build-type:          Simple
 Extra-source-files: CHANGELOG.md
 Cabal-version:       >=1.8
-tested-with:         GHC==7.8.4, GHC==7.10.2, GHC==8.0.2, GHC==8.2.1, GHC==8.4.1
+tested-with:         GHC==8.0.2, GHC==8.2.1, GHC==8.4.1
 
 Source-repository head
   type:          git

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -3,7 +3,7 @@
 -- http://www.haskell.org/cabal/release/cabal-latest/doc/users-guide/authors.html#pkg-descr.
 -- The name of the package.
 Name:                safecopy
-Version:             0.9.4.3
+Version:             0.9.5
 Synopsis:            Binary serialization with version control.
 Description:         An extension to Data.Serialize with built-in version control.
 Homepage:            https://github.com/acid-state/safecopy
@@ -34,11 +34,13 @@ Library
                        array < 0.6,
                        cereal >= 0.5 && < 0.6,
                        bytestring < 0.11,
+                       generic-data >= 0.3,
                        containers >= 0.3 && < 0.7,
                        old-time < 1.2,
                        template-haskell < 2.15,
                        text < 1.3,
                        time < 1.10,
+                       transformers < 0.6,
                        vector >= 0.10 && < 0.13
 
   if !impl(ghc > 8.0)
@@ -67,3 +69,10 @@ Test-suite instances
   Build-depends:       base, cereal, template-haskell, safecopy,
                        containers, time, array, vector, lens >= 4.7 && < 5.0,
                        lens-action, tasty, tasty-quickcheck, quickcheck-instances, QuickCheck
+
+Test-suite generic
+  Type:                exitcode-stdio-1.0
+  Main-is:             generic.hs
+  Hs-Source-Dirs:      test/
+  GHC-Options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  Build-depends:       base, bytestring, cereal, safecopy, HUnit, uuid, uuid-orphans

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -75,4 +75,4 @@ Test-suite generic
   Main-is:             generic.hs
   Hs-Source-Dirs:      test/
   GHC-Options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  Build-depends:       base, bytestring, cereal, safecopy, HUnit, uuid, uuid-orphans
+  Build-depends:       base, bytestring, cereal, safecopy, HUnit

--- a/src/Data/SafeCopy.hs
+++ b/src/Data/SafeCopy.hs
@@ -79,6 +79,7 @@ module Data.SafeCopy
       safeGet
     , safePut
     , SafeCopy(version, kind, getCopy, putCopy, objectProfile, errorTypeName)
+    , SafeCopy'
     , Profile(..)
     , Prim(..)
     , Migrate(..)

--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -52,7 +52,7 @@ import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Storable as VS
 import qualified Data.Vector.Unboxed as VU
 
-instance SafeCopy a => SafeCopy (Prim a) where
+instance SafeCopy' a => SafeCopy (Prim a) where
   kind = primitive
   getCopy = contain $
             do e <- unsafeUnPack getCopy
@@ -145,22 +145,22 @@ instance (SafeCopy a, SafeCopy b) => SafeCopy (a,b) where
     getCopy = contain $ liftM2 (,) safeGet safeGet
     putCopy (a,b) = contain $ safePut a >> safePut b
     errorTypeName = typeName2
-instance (SafeCopy a, SafeCopy b, SafeCopy c) => SafeCopy (a,b,c) where
+instance (SafeCopy' a, SafeCopy' b, SafeCopy' c) => SafeCopy (a,b,c) where
     getCopy = contain $ liftM3 (,,) safeGet safeGet safeGet
     putCopy (a,b,c) = contain $ safePut a >> safePut b >> safePut c
-instance (SafeCopy a, SafeCopy b, SafeCopy c, SafeCopy d) => SafeCopy (a,b,c,d) where
+instance (SafeCopy' a, SafeCopy' b, SafeCopy' c, SafeCopy' d) => SafeCopy (a,b,c,d) where
     getCopy = contain $ liftM4 (,,,) safeGet safeGet safeGet safeGet
     putCopy (a,b,c,d) = contain $ safePut a >> safePut b >> safePut c >> safePut d
-instance (SafeCopy a, SafeCopy b, SafeCopy c, SafeCopy d, SafeCopy e) =>
+instance (SafeCopy' a, SafeCopy' b, SafeCopy' c, SafeCopy' d, SafeCopy' e) =>
          SafeCopy (a,b,c,d,e) where
     getCopy = contain $ liftM5 (,,,,) safeGet safeGet safeGet safeGet safeGet
     putCopy (a,b,c,d,e) = contain $ safePut a >> safePut b >> safePut c >> safePut d >> safePut e
-instance (SafeCopy a, SafeCopy b, SafeCopy c, SafeCopy d, SafeCopy e, SafeCopy f) =>
+instance (SafeCopy' a, SafeCopy' b, SafeCopy' c, SafeCopy' d, SafeCopy' e, SafeCopy' f) =>
          SafeCopy (a,b,c,d,e,f) where
     getCopy = contain $ (,,,,,) <$> safeGet <*> safeGet <*> safeGet <*> safeGet <*> safeGet <*> safeGet
     putCopy (a,b,c,d,e,f) = contain $ safePut a >> safePut b >> safePut c >> safePut d >>
                                       safePut e >> safePut f
-instance (SafeCopy a, SafeCopy b, SafeCopy c, SafeCopy d, SafeCopy e, SafeCopy f, SafeCopy g) =>
+instance (SafeCopy' a, SafeCopy' b, SafeCopy' c, SafeCopy' d, SafeCopy' e, SafeCopy' f, SafeCopy' g) =>
          SafeCopy (a,b,c,d,e,f,g) where
     getCopy = contain $ (,,,,,,) <$> safeGet <*> safeGet <*> safeGet <*> safeGet <*>
                                      safeGet <*> safeGet <*> safeGet
@@ -457,18 +457,18 @@ putGenericVector :: (SafeCopy a, VG.Vector v a) => v a -> Contained Put
 putGenericVector v = contain $ do put (VG.length v)
                                   getSafePut >>= VG.forM_ v
 
-instance SafeCopy a => SafeCopy (V.Vector a) where
+instance SafeCopy' a => SafeCopy (V.Vector a) where
     getCopy = getGenericVector
     putCopy = putGenericVector
 
-instance (SafeCopy a, VP.Prim a) => SafeCopy (VP.Vector a) where
+instance (SafeCopy' a, VP.Prim a) => SafeCopy (VP.Vector a) where
     getCopy = getGenericVector
     putCopy = putGenericVector
 
-instance (SafeCopy a, VS.Storable a) => SafeCopy (VS.Vector a) where
+instance (SafeCopy' a, VS.Storable a) => SafeCopy (VS.Vector a) where
     getCopy = getGenericVector
     putCopy = putGenericVector
 
-instance (SafeCopy a, VU.Unbox a) => SafeCopy (VU.Vector a) where
+instance (SafeCopy' a, VU.Unbox a) => SafeCopy (VU.Vector a) where
     getCopy = getGenericVector
     putCopy = putGenericVector

--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -253,7 +253,7 @@ instance (Integral a, SafeCopy a) => SafeCopy (Ratio a) where
     putCopy r = contain $ do safePut (numerator   r)
                              safePut (denominator r)
     errorTypeName = typeName1
-instance (HasResolution a, Fractional (Fixed a)) => SafeCopy (Fixed a) where
+instance (HasResolution a, Fractional (Fixed a), Typeable a) => SafeCopy (Fixed a) where
     getCopy   = contain $ fromRational <$> safeGet
     putCopy   = contain . safePut . toRational
     errorTypeName = typeName1

--- a/src/Data/SafeCopy/SafeCopy.hs
+++ b/src/Data/SafeCopy/SafeCopy.hs
@@ -283,7 +283,7 @@ data DatatypeInfo =
 -- | Whereas the other 'getSafeGet' is only run when we know we need a
 -- version, this one is run for every field and must decide whether to
 -- read a version or not.  It constructs a Map TypeRep Int32 and reads
--- whent he new TypeRep is not in the map.  Assumes Version a ~ Int32.
+-- whent he new TypeRep is not in the map.
 getSafeGetGeneric ::
   forall a. (SafeCopy a, Typeable a)
   => StateT (Map TypeRep Int32) Get (Get a)
@@ -294,7 +294,6 @@ getSafeGetGeneric
         a_kind    -> do let rep = typeRep (Proxy :: Proxy a)
                         reps <- State.get
                         v <- maybe (lift get) pure (Map.lookup rep reps)
-                        -- This coerce creates an assumption that Version a ~ Int32
                         case constructGetterFromVersion (unsafeCoerce v) a_kind of
                           Right getter -> State.modify (Map.insert rep v) >> return getter
                           Left msg     -> fail msg

--- a/src/Data/SafeCopy/SafeCopy.hs
+++ b/src/Data/SafeCopy/SafeCopy.hs
@@ -217,6 +217,10 @@ instance (GPutFields (K1 R ()) p) => GPutFields U1 p where
 #endif
     {-# INLINE gputFields #-}
 
+instance GPutFields V1 p where
+    gputFields _ _ = undefined
+    {-# INLINE gputFields #-}
+
 ------------------------------------------------------------------------
 
 class GGetCopy f p where
@@ -276,6 +280,10 @@ instance SafeCopy' a => GGetFields (K1 R a) p where
 
 instance GGetFields U1 p where
     ggetFields _p = pure (pure U1)
+    {-# INLINE ggetFields #-}
+
+instance GGetFields V1 p where
+    ggetFields _p = undefined
     {-# INLINE ggetFields #-}
 
 data DatatypeInfo =

--- a/src/Data/SafeCopy/SafeCopy.hs
+++ b/src/Data/SafeCopy/SafeCopy.hs
@@ -214,7 +214,7 @@ getSafePut
 
 -- | The extended_extension kind lets the system know that there is
 --   at least one previous and one future version of this type.
-extended_extension :: (SafeCopy a, Migrate a, Migrate (Reverse a)) => Kind a
+extended_extension :: (Migrate a, Migrate (Reverse a)) => Kind a
 extended_extension = Extended extension
 
 -- | The extended_base kind lets the system know that there is
@@ -227,7 +227,7 @@ extended_base = Extended base
 --   can only extend a single other data type. However, it is
 --   perfectly fine to build chains of extensions. The migrations
 --   between each step is handled automatically.
-extension :: (SafeCopy a, Migrate a) => Kind a
+extension :: Migrate a => Kind a
 extension = Extends Proxy
 
 -- | The default kind. Does not extend any type.
@@ -379,7 +379,7 @@ versionFromProxy _ = version
 versionFromKind :: (SafeCopy a) => Kind a -> Version a
 versionFromKind _ = version
 
-versionFromReverseKind :: (SafeCopy a, SafeCopy (MigrateFrom (Reverse a))) => Kind a -> Version (MigrateFrom (Reverse a))
+versionFromReverseKind :: (SafeCopy (MigrateFrom (Reverse a))) => Kind a -> Version (MigrateFrom (Reverse a))
 versionFromReverseKind _ = version
 
 kindFromProxy :: SafeCopy a => Proxy a -> Kind a

--- a/test/generic.hs
+++ b/test/generic.hs
@@ -25,20 +25,11 @@ import Data.Typeable hiding (Proxy)
 import Data.ByteString (ByteString, unpack)
 import Data.Char (chr)
 import Data.Word (Word8, Word32)
-import Data.UUID.Orphans ()
-import Data.UUID.Types (fromString)
-import Data.UUID.Types.Internal (UUID(..))
 
 -- Test types
 data Foo = Foo Int Char deriving (Generic, Show, Eq)
 data Bar = Bar Float Foo deriving (Generic, Show, Eq)
 data Baz = Baz1 Int | Baz2 Bool deriving (Generic, Show, Eq)
-
-#if MIN_VERSION_safecopy(0,9,5)
-instance SafeCopy UUID where version = 0
-#else
-$(deriveSafeCopy 0 'base ''UUID)
-#endif
 
 #if 0
 safePutTest :: forall a. (SafeCopy' a, Generic a, GPutCopy (Rep a) DatatypeInfo, GConstructors (Rep a)) => a -> Put
@@ -243,15 +234,6 @@ instance SafeCopy T2G where version = 4; kind = base
 instance SafeCopy T3G where version = 5; kind = base
 instance SafeCopy T4G where version = 6; kind = base
 
-newtype ReportID = ReportID { unReportID :: UUID } deriving (Generic, Eq, Ord, Typeable, Show)
-
-instance SafeCopy ReportID where version = 1
-
-u :: UUID
-Just u = fromString "de89101a-e87f-4677-8ded-47b8963493c4"
-rid :: ReportID
-rid = ReportID u
-
 orderTests :: Test
 orderTests =
   let -- When I thought to myself "what should the output be type Baz"
@@ -289,8 +271,6 @@ main = do
       , roundTrip file1
       , roundTrip file2
       , roundTrip file3
-      , roundTrip u
-      , roundTrip rid
       , compareBytes fooTH foo
       , compareBytes barTH bar
       , compareBytes baz1TH baz1

--- a/test/generic.hs
+++ b/test/generic.hs
@@ -12,6 +12,9 @@
 {-# OPTIONS -Wno-missing-signatures #-}
 
 import GHC.Generics
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
 import Data.SafeCopy
 import Data.SafeCopy.Internal
 import Data.Serialize (runGet, runPut, Serialize)

--- a/test/generic.hs
+++ b/test/generic.hs
@@ -1,0 +1,298 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS -Wno-missing-signatures #-}
+
+import GHC.Generics
+import Data.SafeCopy
+import Data.SafeCopy.Internal
+import Data.Serialize (runGet, runPut, Serialize)
+import Text.Printf
+import Test.HUnit (Test(..), assertEqual, runTestTT)
+--import Generic.Data as G hiding (unpack)
+
+-- Debugging
+import Data.Typeable hiding (Proxy)
+--import Debug.Trace
+import Data.ByteString (ByteString, unpack)
+import Data.Char (chr)
+import Data.Word (Word8, Word32)
+import Data.UUID.Orphans ()
+import Data.UUID.Types (fromString)
+import Data.UUID.Types.Internal (UUID(..))
+
+-- Test types
+data Foo = Foo Int Char deriving (Generic, Show, Eq)
+data Bar = Bar Float Foo deriving (Generic, Show, Eq)
+data Baz = Baz1 Int | Baz2 Bool deriving (Generic, Show, Eq)
+
+#if MIN_VERSION_safecopy(0,9,5)
+instance SafeCopy UUID where version = 0
+#else
+$(deriveSafeCopy 0 'base ''UUID)
+#endif
+
+#if 0
+safePutTest :: forall a. (SafeCopy' a, Generic a, GPutCopy (Rep a) DatatypeInfo, GConstructors (Rep a)) => a -> Put
+safePutTest a =
+  case runPut p1 == runPut p2 of
+    True -> p1
+    False -> trace ("safePutTest failed for " ++ show (typeRep (Proxy :: Proxy a)) ++ "\n custom: " ++ showBytes (runPut p1) ++ "\n generic: " ++ showBytes (runPut p2)) p1
+  where
+    p1 = safePut a
+    p2 = safePutGeneric a
+#endif
+
+----------------------------------------------
+
+-- Compare a value to the result of encoding and then decoding it.
+roundTrip :: forall a. (SafeCopy a, Typeable a, Eq a, Show a) => a -> Test
+roundTrip x = do
+  -- putStrLn ("\n========== " ++ show x ++ " :: " ++ show (typeRep (Proxy :: Proxy a)) ++ " ==========")
+  let d = runPut (safePut x) -- Use custom putCopy/getCopy implementation if present
+      a :: Either String a
+      a = runGet safeGet d
+  TestCase (assertEqual ("roundTrip " ++ show x ++ " :: " ++ show (typeRep (Proxy :: Proxy a))) (Right x) a)
+
+-- Test whether two values of different types have the same encoded
+-- representation.  This is used here on types of similar shape to
+-- test whether the generic SafeCopy instance matches the template
+-- haskell instance.
+compareBytes ::
+  forall expected actual. (SafeCopy expected, Typeable expected,
+                           SafeCopy actual, Typeable actual)
+  => expected -> actual -> Test
+compareBytes e a =
+  TestCase (assertEqual ("compareBytes " ++ show (typeRep (Proxy :: Proxy expected)) ++ " " ++
+                                            show (typeRep (Proxy :: Proxy actual)))
+              (showBytes (runPut $ safePut e))
+              (showBytes (runPut $ safePut a)))
+
+showBytes :: ByteString -> String
+showBytes b = mconcat (fmap f (unpack b))
+   where f :: Word8 -> String
+         f 192 = "[G|"
+         f 193 = "[C|"
+         f 194 = "[T|"
+         f 195 = "]_ "
+         f 196 = " _<"
+         f 197 = ">_ "
+         f c | c >= 32 && c < 127 = [' ', chr (fromIntegral c), ' ']
+         f c | c == 0 = " __"
+         f c = printf " %02x" c
+
+-----------------------------
+-- Test Types and Values
+-----------------------------
+
+foo = Foo maxBound 'x'
+bar = Bar 1.5 foo
+baz1 = Baz1 3
+baz2 = Baz2 True
+
+-- These instances will use the generic putCopy and getCopy
+instance SafeCopy Foo where version = 3; kind = base
+instance SafeCopy Bar where version = 4; kind = base
+instance SafeCopy Baz where version = 5; kind = base
+
+-- Copies of the types above with generated SafeCopy instances
+data FooTH = FooTH Int Char deriving (Generic, Serialize, Show, Eq)
+data BarTH = BarTH Float FooTH deriving (Generic, Serialize, Show, Eq)
+data BazTH = Baz1TH Int | Baz2TH Bool deriving (Generic, Serialize, Show, Eq)
+
+fooTH = FooTH maxBound 'x'
+barTH = BarTH 1.5 fooTH
+baz1TH = Baz1TH 3
+baz2TH = Baz2TH True
+
+-- For comparison, these instances have the generated implementations
+-- of putCopy and getCopy
+#if 1
+$(deriveSafeCopy 3 'base ''FooTH)
+$(deriveSafeCopy 4 'base ''BarTH)
+$(deriveSafeCopy 5 'base ''BazTH)
+#else
+instance SafeCopy FooTH where
+      putCopy (FooTH a1_aeVVN a2_aeVVO)
+        = contain
+            (do safePut_Int_aeVVP <- getSafePut
+                safePut_Char_aeVVQ <- getSafePut
+                safePut_Int_aeVVP a1_aeVVN
+                safePut_Char_aeVVQ a2_aeVVO
+                return ())
+      getCopy
+        = contain
+            ((Data.Serialize.Get.label "Main.FooTH:")
+               (do safeGet_Int_aeVVR <- getSafeGet
+                   safeGet_Char_aeVVS <- getSafeGet
+                   ((return FooTH <*> safeGet_Int_aeVVR) <*> safeGet_Char_aeVVS)))
+      version = 3
+      kind = base
+      errorTypeName _ = "Main.FooTH"
+
+instance SafeCopy BarTH where
+      putCopy (BarTH a1_aeVXE a2_aeVXF)
+        = contain
+            (do safePut_Float_aeVXG <- getSafePut
+                safePut_FooTH_aeVXH <- getSafePut
+                safePut_Float_aeVXG a1_aeVXE
+                safePut_FooTH_aeVXH a2_aeVXF
+                return ())
+      getCopy
+        = contain
+            ((Data.Serialize.Get.label "Main.BarTH:")
+               (do safeGet_Float_aeVXI <- getSafeGet
+                   safeGet_FooTH_aeVXJ <- getSafeGet
+                   ((return BarTH <*> safeGet_Float_aeVXI) <*> safeGet_FooTH_aeVXJ)))
+      version = 4
+      kind = base
+      errorTypeName _ = "Main.BarTH"
+
+instance SafeCopy BazTH where
+      putCopy (Baz1TH a1_aeVZv)
+        = contain
+            (do Data.Serialize.Put.putWord8 0
+                safePut_Int_aeVZw <- getSafePut
+                safePut_Int_aeVZw a1_aeVZv
+                return ())
+      putCopy (Baz2TH a1_aeVZx)
+        = contain
+            (do Data.Serialize.Put.putWord8 1
+                safePut_Bool_aeVZy <- getSafePut
+                safePut_Bool_aeVZy a1_aeVZx
+                return ())
+      getCopy
+        = contain
+            ((Data.Serialize.Get.label "Main.BazTH:")
+               (do tag_aeVZz <- Data.Serialize.Get.getWord8
+                   case tag_aeVZz of
+                     0 -> do safeGet_Int_aeVZA <- getSafeGet
+                             (return Baz1TH <*> safeGet_Int_aeVZA)
+                     1 -> do safeGet_Bool_aeVZB <- getSafeGet
+                             (return Baz2TH <*> safeGet_Bool_aeVZB)
+                     _ -> fail
+                            ("Could not identify tag \""
+                               ++
+                                 (show tag_aeVZz
+                                    ++
+                                      "\" for type \"Main.BazTH\" that has only 2 constructors.  Maybe your data is corrupted?"))))
+      version = 5
+      kind = base
+      errorTypeName _ = "Main.BazTH"
+#endif
+
+data File
+    = File { _fileChksum :: Checksum             -- ^ The checksum of the file's contents
+           , _fileMessages :: [String]           -- ^ Messages received while manipulating the file
+           , _fileExt :: String                  -- ^ Name is formed by appending this to checksum
+           } deriving (Generic, Eq, Ord, Show)
+
+data FileSource
+    = TheURI String
+    | ThePath FilePath
+    deriving (Generic, Eq, Ord, Show)
+
+type Checksum = String
+
+$(deriveSafeCopy 10 'base ''File)
+$(deriveSafeCopy 11 'base ''FileSource)
+
+file1 = File ("checksum") [] ".jpg"
+file2 = File ("checksum") [] ".jpg"
+file3 = File ("checksum") [] ".jpg"
+
+----------------------------------------------
+-- Demonstration of the ordering issue
+----------------------------------------------
+
+data T1 = T1 Char T2 T3 deriving (Generic, Show)
+data T2 = T2 Char deriving (Generic, Show)
+data T3 = T3 Char deriving (Generic, Show)
+data T4 = T4 Word32 Word32 Word32 deriving (Generic, Show)
+
+t1 = T1 'a' (T2 'b') (T3 'c')
+t2 = (T2 'b')
+t3 = (T3 'c')
+t4 = T4 100 200 300
+
+$(deriveSafeCopy 3 'base ''T1)
+$(deriveSafeCopy 4 'base ''T2)
+$(deriveSafeCopy 5 'base ''T3)
+$(deriveSafeCopy 6 'base ''T4)
+
+data T1G = T1G Char T2G T3G deriving (Generic, Show)
+data T2G = T2G Char deriving (Generic, Show)
+data T3G = T3G Char deriving (Generic, Show)
+data T4G = T4G Word32 Word32 Word32 deriving (Generic, Show)
+
+t1g = T1G 'a' (T2G 'b') (T3G 'c')
+t2g = (T2G 'b')
+t3g = (T3G 'c')
+t4g = T4G 100 200 300
+
+instance SafeCopy T1G where version = 3; kind = base
+instance SafeCopy T2G where version = 4; kind = base
+instance SafeCopy T3G where version = 5; kind = base
+instance SafeCopy T4G where version = 6; kind = base
+
+newtype ReportID = ReportID { unReportID :: UUID } deriving (Generic, Eq, Ord, Typeable, Show)
+
+instance SafeCopy ReportID where version = 1
+
+u :: UUID
+Just u = fromString "de89101a-e87f-4677-8ded-47b8963493c4"
+rid :: ReportID
+rid = ReportID u
+
+orderTests :: Test
+orderTests =
+  let -- When I thought to myself "what should the output be type Baz"
+      -- without reference to reality, this is what I came up with.
+      _expected :: ByteString
+      _expected = ("\NUL\NUL\NUL\ETX" <> "\NUL\NUL\NUL\NUL" <> "a" <> "\NUL\NUL\NUL\EOT" <> "\NUL\NUL\NUL\NUL" <> "b" <> "\NUL\NUL\NUL\ENQ" <> "\NUL\NUL\NUL\NUL" <> "c")
+      --                  T1                   Char            'a'            T2                    Char          'b'            T3                   Char           'c'
+      -- But this is reality - the type, followed by its three field
+      -- types, followed by its three field values.
+      actual :: ByteString
+      actual = ("\NUL\NUL\NUL\ETX" <> "\NUL\NUL\NUL\NUL" <> "\NUL\NUL\NUL\EOT" <> "\NUL\NUL\NUL\ENQ" <> "a" <> "\NUL\NUL\NUL\NUL" <> "b" <> "\NUL\NUL\NUL\NUL" <> "c") in
+      --               T1                   Char                    T2                    T3            'a'           Char           'b'            Char          'c'
+  TestList
+     [ TestCase (assertEqual "actual template haskell safeput output" (showBytes actual) (showBytes (runPut (safePut t1))))
+     , TestCase (assertEqual "what the new implementation does"       (showBytes actual) (showBytes (runPut (safePut t1g))))
+     ]
+
+main = do
+  runTestTT
+    (TestList
+      [ orderTests
+      , roundTrip ()
+      , roundTrip ("hello" :: String)
+      , roundTrip foo
+      , roundTrip fooTH
+      , roundTrip bar
+      , roundTrip barTH
+      , roundTrip baz1
+      , roundTrip baz1TH
+      , roundTrip baz2
+      , roundTrip baz2TH
+      , roundTrip (Just 'x')
+      , roundTrip (Nothing :: Maybe Char)
+      , roundTrip ('a', (123 :: Int), ("hello" :: String))
+      , roundTrip file1
+      , roundTrip file2
+      , roundTrip file3
+      , roundTrip u
+      , roundTrip rid
+      , compareBytes fooTH foo
+      , compareBytes barTH bar
+      , compareBytes baz1TH baz1
+      , compareBytes baz2TH baz2
+      ])


### PR DESCRIPTION
Since 2011 there have been default implementations for SafeCopy's putCopy and getCopy, but these just used the serialize operations to create values that could not be migrated and, I suspect, might lead to problems if used for values that themselves contained types with SafeCopy instances.  This implementation has been inter-operating well for me with the instances produced by deriveSafeCopy, and in fact I have now removed them all.  You can now write

    instance SafeCopy AnyGenericInstance where version = 8; kind = extension

The limitations of the implementation are

1. ~~The version type is pinned to Int32~~ (oops, Version has always been pinned to Int32)
2. The values must have Typeable instances

 If anyone can puzzle out ~~either of these issues~~ this issue that would be interesting.  Its necessary to keep track of which types you've output version tags for, so I build a Set of TypeRep in the State monad.  Is there a GHC.Generic alternative to TypeRep?

The patch adds dependencies on generic-data and transformers.  I've bumped the version number to 0.9.5 so the MIN_VERSION_safecopy macro can be used.  Fixes issue #2 .