### PR TITLE
Forbid `template-haskell-2.15`

### DIFF
--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -37,7 +37,7 @@ Library
                        generic-data >= 0.3,
                        containers >= 0.3 && < 0.7,
                        old-time < 1.2,
-                       template-haskell < 2.16,
+                       template-haskell < 2.15,
                        text < 1.3,
                        time < 1.10,
                        transformers < 0.6,


### PR DESCRIPTION
Looks like the release was made with incorrect bounds.

![Screenshot from 2019-09-25 15-19-15](https://user-images.githubusercontent.com/51087/65600041-f1c0fd00-dfa7-11e9-809e-0f4c6115a68f.png)
