### PR TITLE
GHC 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250216",["github","safecopy.cabal"])
+# REGENDATA ("0.19.20250821",["github","safecopy.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.14.0.20250819
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -47,9 +52,9 @@ jobs:
             compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -106,15 +111,30 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,10 +244,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_safecopy}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package safecopy" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package safecopy" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package safecopy" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: containers
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(safecopy)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -253,16 +291,6 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set containers-0.8
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.8' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.8' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.8' all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>= 0.8' all ; fi
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ubuntu-latest]
-        ghc: ['9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4']
+        ghc: ['9.12', '9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4']
         include:
           - os: macos-latest
-            ghc: '9.10'
+            ghc: '9.12'
           - os: windows-latest
-            ghc: '9.10'
+            ghc: '9.12'
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.10.4.3
+--------
+
+_Andreas Abel, 2025-08-27_
+
+- Remove old code for GHC 7
+- Tested with GHC 8.0 - 9.14 alpha1
+
 0.10.4
 ======
 
@@ -53,5 +61,3 @@ This change originated as a modification to the way `cereal` 0.5 serializes `Flo
 [https://github.com/GaloisInc/cereal/commit/47d839609413e3e9d1147b99c34ae421ae36bced](https://github.com/GaloisInc/cereal/commit/47d839609413e3e9d1147b99c34ae421ae36bced)
 
 [https://github.com/GaloisInc/cereal/issues/35](https://github.com/GaloisInc/cereal/issues/35)
-
-

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,11 +1,11 @@
 branches: master
 installed: +all
 
-constraint-set containers-0.8
-  ghc: >= 8.2
-  constraints: containers ^>= 0.8
-  tests: True
-  run-tests: True
+-- constraint-set containers-0.8
+--   ghc: >= 8.2
+--   constraints: containers ^>= 0.8
+--   tests: True
+--   run-tests: True
 
-raw-project
-  allow-newer: containers
+-- raw-project
+--   allow-newer: containers

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -14,10 +14,11 @@ Extra-source-files:  CHANGELOG.md
 Cabal-version:       >=1.10
 
 tested-with:
-  GHC == 9.12.1
-  GHC == 9.10.1
+  GHC == 9.14.1
+  GHC == 9.12.2
+  GHC == 9.10.2
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -1,6 +1,6 @@
 Name:                safecopy
 Version:             0.10.4.2
-x-revision:          11
+x-revision:          12
 Synopsis:            Binary serialization with version control.
 Description:         An extension to Data.Serialize with built-in version control.
 Homepage:            https://github.com/acid-state/safecopy
@@ -49,9 +49,9 @@ Library
                      , generic-data     >= 0.3.0.0   && < 2
                      , containers       >= 0.5.7.1   && < 1
                      , old-time         >= 1.1.0.3   && < 1.2
-                     , template-haskell >= 2.11.0.0  && < 2.24
+                     , template-haskell >= 2.11.0.0  && < 2.25
                      , text             >= 1.2.2.2   && < 1.3 || >= 2.0 && < 2.2
-                     , time             >= 1.6.0.1   && < 1.15
+                     , time             >= 1.6.0.1   && < 2
                      , transformers     >= 0.5.2.0   && < 0.7
                      , vector           >= 0.11.0.0  && < 0.14
 

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -1,6 +1,6 @@
+Cabal-version:       1.18
 Name:                safecopy
-Version:             0.10.4.2
-x-revision:          12
+Version:             0.10.4.3
 Synopsis:            Binary serialization with version control.
 Description:         An extension to Data.Serialize with built-in version control.
 Homepage:            https://github.com/acid-state/safecopy
@@ -10,8 +10,8 @@ Maintainer:          Lemmih <lemmih@gmail.com>, David Fox <dsf@seereason.com>
 -- Copyright:
 Category:            Data, Parsing
 Build-type:          Simple
-Extra-source-files:  CHANGELOG.md
-Cabal-version:       >=1.10
+
+Extra-doc-files:  CHANGELOG.md
 
 tested-with:
   GHC == 9.14.1

--- a/safecopy.cabal
+++ b/safecopy.cabal
@@ -82,8 +82,6 @@ Test-suite instances
                      , lens-action
                      , tasty
                      , tasty-quickcheck
-                     , quickcheck-instances
-                     , QuickCheck >= 2.8.2 && < 3
 
 Test-suite generic
   Default-language:    Haskell2010

--- a/src/Data/SafeCopy/Instances.hs
+++ b/src/Data/SafeCopy/Instances.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable, FlexibleContexts, UndecidableInstances, TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.SafeCopy.Instances where
@@ -171,7 +173,7 @@ instance SafeCopy Natural where
 --
 -- https://github.com/GaloisInc/cereal/commit/47d839609413e3e9d1147b99c34ae421ae36bced
 -- https://github.com/GaloisInc/cereal/issues/35
-newtype CerealFloat040 = CerealFloat040 { unCerealFloat040 :: Float} deriving (Show, Typeable)
+newtype CerealFloat040 = CerealFloat040 { unCerealFloat040 :: Float} deriving (Show)
 instance SafeCopy CerealFloat040 where
     getCopy = contain (CerealFloat040 <$> liftM2 encodeFloat get get)
     putCopy (CerealFloat040 float) = contain (put (decodeFloat float))
@@ -192,7 +194,7 @@ instance SafeCopy Float where
 --
 -- https://github.com/GaloisInc/cereal/commit/47d839609413e3e9d1147b99c34ae421ae36bced
 -- https://github.com/GaloisInc/cereal/issues/35
-newtype CerealDouble040 = CerealDouble040 { unCerealDouble040 :: Double} deriving (Show, Typeable)
+newtype CerealDouble040 = CerealDouble040 { unCerealDouble040 :: Double} deriving (Show)
 instance SafeCopy CerealDouble040 where
     getCopy = contain (CerealDouble040 <$> liftM2 encodeFloat get get)
     putCopy (CerealDouble040 double) = contain (put (decodeFloat double))

--- a/stack-9.10.yaml
+++ b/stack-9.10.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2025-03-11
+resolver: lts-24.6

--- a/stack-9.12.yaml
+++ b/stack-9.12.yaml
@@ -1,0 +1,1 @@
+resolver: nightly-2025-08-23

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,1 +1,1 @@
-resolver: lts-22.43
+resolver: lts-22.44

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,1 +1,1 @@
-resolver: lts-23.14
+resolver: lts-23.28


### PR DESCRIPTION
- Add GHC 9.12 to Stack CI
- Bump Haskell CI to GHC 9.14 alpha1
  
- Relax dependencies for GHC 9.14, remove unused dependencies of testsuite